### PR TITLE
Adds Mobile NavBar to Home Depot Mock Website

### DIFF
--- a/bootstrap/mocks/home-depot/index.html
+++ b/bootstrap/mocks/home-depot/index.html
@@ -15,6 +15,7 @@
     />
     <link rel="stylesheet" href="style.css">
   </head>
+
   <body>
     <!-- Orange Button Bar -->
     <aside class="container-fluid text-center text-white p-1">
@@ -22,12 +23,36 @@
     </aside>
 
     <!-- Mark this to be a nav -->
-    <nav class="navbar">
+    <nav class="navbar navbar-expand-lg navbar-light">
       <!-- Extend the width of the screen -->
-      <div class="container-fluid">
+      <div id="nav" class="container-fluid">
         <!-- Home Depot Brand Name -->
         <a class="navbar-brand" href="https://www.homedepot.com/"><img class="" src="https://www.rewindandcapture.com/wp-content/uploads/2020/08/Home-Depot-Logo.jpg" alt="Home Depot Logo" height="37"></a>
-        <!-- Brand Menu -->
+        
+        <!-- Define hamburger menu icon -->
+        <button
+          class="navbar-toggler border-0 float-md-end"
+          type="button"
+          data-bs-toggle="collapse"
+          data-bs-target="#navbarSupportedContent"
+          aria-controls="navbarSupportedContent"
+          aria-expanded="false"
+          aria-label="Toggle navigation"
+        >
+          <span class="navbar-toggler-icon" id="hamburger-menu"></span>
+        </button>
+
+        <!-- Dummy links -- notice the connection is shared by navbarSupportedContent -->
+        <div class="collapse navbar-collapse" id="navbarSupportedContent">
+
+            <!-- Styling the actual links now... -->
+          <ul class="navbar-nav me-auto mb-2 mb-lg-0">
+            <!-- Link item -->
+            <li class="nav-item">
+              <a class="nav-link active" aria-current="page" href="#">Home</a>
+            </li>
+          </ul>
+      </div>
       </div>
 
 

--- a/bootstrap/mocks/home-depot/index.html
+++ b/bootstrap/mocks/home-depot/index.html
@@ -6,7 +6,10 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>The Home Depot</title>
 
+    <!-- Bootstrap Icons -->
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.8.1/font/bootstrap-icons.css">
 
+    <!-- Bootstrap -->
     <link
       href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css"
       rel="stylesheet"
@@ -61,6 +64,13 @@
         <form class="form-inline my-2 my-lg-2 m-3">
           <input class="form-control mr-sm-2" type="search" placeholder="Search" aria-label="Search">
         </form>
+        <!-- End Search bar -->
+
+        <i class="bi bi-person"></i>
+        <i class="bi bi-heart"></i>
+        <i class="bi bi-cart"></i>
+        
+
 
         <!-- Dummy links -- notice the connection is shared by navbarSupportedContent -->
         <div class="collapse navbar-collapse order-0" id="navbarSupportedContent">

--- a/bootstrap/mocks/home-depot/index.html
+++ b/bootstrap/mocks/home-depot/index.html
@@ -61,14 +61,16 @@
         <!-- End of Dropdown -->
 
         <!-- Search Bar -->
-        <form class="form-inline my-2 my-lg-2 m-3">
-          <input class="form-control mr-sm-2" type="search" placeholder="Search" aria-label="Search">
+        <form class="form-inline my-2 my-lg-2 mx-5">
+          <input id="searchBar" class="form-control mr-sm-2" type="search" placeholder="Search" aria-label="Search">
         </form>
         <!-- End Search bar -->
 
-        <i class="bi bi-person"></i>
-        <i class="bi bi-heart"></i>
-        <i class="bi bi-cart"></i>
+        <div id="navIcons">
+          <i class="bi bi-person mx-3"></i>
+          <i class="bi bi-heart mx-3"></i>
+          <i class="bi bi-cart mx-3"></i>
+        </div>
         
 
 

--- a/bootstrap/mocks/home-depot/index.html
+++ b/bootstrap/mocks/home-depot/index.html
@@ -16,13 +16,23 @@
     <link rel="stylesheet" href="style.css">
   </head>
   <body>
+    <!-- Orange Button Bar -->
     <aside class="container-fluid text-center text-white p-1">
       <span>FREE IN-STORE PICKUP Over one million online items eligible. ></span>
     </aside>
-    <nav>
+
+    <!-- Mark this to be a nav -->
+    <nav class="navbar">
+      <!-- Extend the width of the screen -->
+      <div class="container-fluid">
+        <!-- Home Depot Brand Name -->
+        <a class="navbar-brand" href="https://www.homedepot.com/"><img class="" src="https://www.rewindandcapture.com/wp-content/uploads/2020/08/Home-Depot-Logo.jpg" alt="Home Depot Logo" height="37"></a>
+        <!-- Brand Menu -->
+      </div>
+
 
     </nav>
-    <h1>Hello World!</h1>
+    
 
 
 

--- a/bootstrap/mocks/home-depot/index.html
+++ b/bootstrap/mocks/home-depot/index.html
@@ -42,8 +42,23 @@
           <span class="navbar-toggler-icon" id="hamburger-menu"></span>
         </button>
 
+        <!-- Dropdown -->
+        <ul class="navbar-nav">
+          <li class="nav-item dropdown">
+            <a class="nav-link dropdown-toggle" href="#" id="navbarDropdownMenuLink" role="button" data-bs-toggle="dropdown" aria-expanded="false">
+              You're shopping
+            </a>
+            <ul class="dropdown-menu dropdown-menu-light" aria-labelledby="navbarDropdownMenuLink">
+              <li><a class="dropdown-item" href="#">Action</a></li>
+              <li><a class="dropdown-item" href="#">Another action</a></li>
+              <li><a class="dropdown-item" href="#">Something else here</a></li>
+            </ul>
+          </li>
+        </ul>
+        <!-- End of Dropdown -->
+
         <!-- Dummy links -- notice the connection is shared by navbarSupportedContent -->
-        <div class="collapse navbar-collapse" id="navbarSupportedContent">
+        <div class="collapse navbar-collapse order-0" id="navbarSupportedContent">
 
             <!-- Styling the actual links now... -->
           <ul class="navbar-nav me-auto mb-2 mb-lg-0">

--- a/bootstrap/mocks/home-depot/index.html
+++ b/bootstrap/mocks/home-depot/index.html
@@ -57,6 +57,11 @@
         </ul>
         <!-- End of Dropdown -->
 
+        <!-- Search Bar -->
+        <form class="form-inline my-2 my-lg-2 m-3">
+          <input class="form-control mr-sm-2" type="search" placeholder="Search" aria-label="Search">
+        </form>
+
         <!-- Dummy links -- notice the connection is shared by navbarSupportedContent -->
         <div class="collapse navbar-collapse order-0" id="navbarSupportedContent">
 

--- a/bootstrap/mocks/home-depot/style.css
+++ b/bootstrap/mocks/home-depot/style.css
@@ -7,6 +7,26 @@ aside:hover {
     cursor: pointer;
 }
 
+
+/* search bar */
+#searchBar {
+    width: 20em;
+}
+
+#navIcons {
+    font-size: 1.5em;
+}
+
+@media (max-width:875px) {
+    #searchBar {
+        display: none;
+    }
+
+    #navIcons {
+        display: none;
+    }
+  }
+
 @media (max-width:1000px) {
     #nav {
         justify-content: flex-start;

--- a/bootstrap/mocks/home-depot/style.css
+++ b/bootstrap/mocks/home-depot/style.css
@@ -6,3 +6,14 @@ aside:hover {
     text-decoration: underline;
     cursor: pointer;
 }
+
+@media (max-width:1000px) {
+    #nav {
+        justify-content: flex-start;
+        
+    }
+  }
+
+  #hamburger-menu {
+    color: orange;
+  }


### PR DESCRIPTION
Mock:
![image](https://user-images.githubusercontent.com/52969350/159704992-213a02eb-5722-4dff-8635-4dddcc5b5dd2.png)

Home Depot:
![image](https://user-images.githubusercontent.com/52969350/159705057-541a9801-df45-448f-a8fc-f0b2c576dc6c.png)

Note: Home Depot cuts out the rest of the icons, both screenshots are the full window when window is resized.